### PR TITLE
Expose the IncrementVersion function as a libbit

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -286,3 +286,20 @@ editor:
     branch: "master"
     sha: "d1145f3"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "DefineLibbit"
+  group: "satellite-of-love"
+  artifact: "libbit-rugs"
+  version: "0.2.0"
+  origin:
+    repo: "git@github.com:satellite-of-love/libbit-rugs.git"
+    branch: "master"
+    sha: "18fd18b"
+  parameters:
+    - "name": "IncrementVersion"
+    - "sourceFile": ".atomist/editors/libbits/IncrementVersion.ts"
+

--- a/.atomist/editors/BumpVersion.ts
+++ b/.atomist/editors/BumpVersion.ts
@@ -18,6 +18,7 @@ import { Project } from "@atomist/rug/model/Project";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 
+import { incrementVersion } from "./libbits/IncrementVersion";
 import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 
 /**
@@ -66,28 +67,3 @@ export class BumpVersion implements EditProject {
 }
 
 export const bumpVersion = new BumpVersion();
-
-export function incrementVersion(version: string, component: "major" | "minor" | "patch"): string {
-    const versionRegex = /^(\d+)\.(\d+)\.(\d+)([-.].*)?$/;
-    const versionMatch = versionRegex.exec(version);
-    if (versionMatch === null || versionMatch.length < 4) {
-        throw new Error(`version does not appear to be valid: ${version}`);
-    }
-
-    let major = parseInt(versionMatch[1], 10);
-    let minor = parseInt(versionMatch[2], 10);
-    let patch = parseInt(versionMatch[3], 10);
-    const rest = (versionMatch[4] != null) ? versionMatch[4] : "";
-
-    if (component === "major") {
-        major = major + 1;
-        minor = 0;
-        patch = 0;
-    } else if (component === "minor") {
-        minor = minor + 1;
-        patch = 0;
-    } else if (component === "patch") {
-        patch = patch + 1;
-    }
-    return `${major}.${minor}.${patch}${rest}`;
-}

--- a/.atomist/editors/libbit/IncrementVersionLibbit.ts
+++ b/.atomist/editors/libbit/IncrementVersionLibbit.ts
@@ -1,0 +1,36 @@
+import { File, Project } from "@atomist/rug/model/Core";
+import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
+import { EditProject } from "@atomist/rug/operations/ProjectEditor";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
+
+/**
+ * Run this to copy IncrementVersion into your project
+ */
+@Editor("IncrementVersionLibbit", "Run this to copy IncrementVersion into your project")
+@Tags("libbit")
+export class IncrementVersionLibbit implements EditProject {
+
+    public edit(project: Project) {
+
+        const sourceFiles = [ ".atomist/editors/libbits/IncrementVersion.ts" ];
+        const testFiles = [ ".atomist/mocha/IncrementVersionTest.ts" ];
+
+        const allFiles = sourceFiles.concat(testFiles);
+
+        const alreadyExisting = allFiles.filter((f) => project.fileExists(f));
+        if (alreadyExisting.length > 0) {
+            console.log(`File ${alreadyExisting.join(" and ")} already exists. Exiting`);
+            return;
+        }
+
+
+        allFiles.forEach((f) => {
+            project.copyEditorBackingFileOrFail(f);
+        });
+
+        // TODO: some atomist config operation to make a link
+        // TODO: calculate and move the files to a package (if there's a 'libbit' package put them there?)
+    }
+}
+
+export const sampleLibbit = new IncrementVersionLibbit();

--- a/.atomist/editors/libbits/IncrementVersion.ts
+++ b/.atomist/editors/libbits/IncrementVersion.ts
@@ -1,0 +1,24 @@
+export function incrementVersion(version: string, component: "major" | "minor" | "patch"): string {
+    const versionRegex = /^(\d+)\.(\d+)\.(\d+)([-.].*)?$/;
+    const versionMatch = versionRegex.exec(version);
+    if (versionMatch === null || versionMatch.length < 4) {
+        throw new Error(`version does not appear to be valid: ${version}`);
+    }
+
+    let major = parseInt(versionMatch[1], 10);
+    let minor = parseInt(versionMatch[2], 10);
+    let patch = parseInt(versionMatch[3], 10);
+    const rest = (versionMatch[4] != null) ? versionMatch[4] : "";
+
+    if (component === "major") {
+        major = major + 1;
+        minor = 0;
+        patch = 0;
+    } else if (component === "minor") {
+        minor = minor + 1;
+        patch = 0;
+    } else if (component === "patch") {
+        patch = patch + 1;
+    }
+    return `${major}.${minor}.${patch}${rest}`;
+}

--- a/.atomist/mocha/IncrementVersionTest.ts
+++ b/.atomist/mocha/IncrementVersionTest.ts
@@ -17,7 +17,7 @@
 import "mocha";
 import assert = require("power-assert");
 
-import { incrementVersion } from "../editors/BumpVersion";
+import { incrementVersion } from "../editors/libbits/IncrementVersion";
 
 describe("incrementVersion", () => {
 

--- a/.atomist/package-lock.json
+++ b/.atomist/package-lock.json
@@ -30,9 +30,9 @@
       "dev": true
     },
     "@types/js-yaml": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.5.30.tgz",
-      "integrity": "sha1-9VURjAIjGOV+NtgDN5y47jjuIKc=",
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.5.31.tgz",
+      "integrity": "sha512-tDsBKuC7nlShdRbR+rCe6qrs9Fqodi7WUxyeysCwKG0kWFWsisyZ8FhmYhCF6+lt3XhIwSExaD1MxidYtRW15w==",
       "dev": true
     },
     "@types/mocha": {
@@ -231,12 +231,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
       "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
-      "dev": true
-    },
-    "empower": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.2.tgz",
-      "integrity": "sha1-i08ojBw5kAlOJUyNzhXFU9B/OaQ=",
       "dev": true
     },
     "empower-assert": {
@@ -657,10 +651,18 @@
       "dev": true
     },
     "power-assert": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.2.tgz",
-      "integrity": "sha1-QzGc0P7NMiHydvHMSf+i6uuaGBU=",
-      "dev": true
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
+      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
+      "dev": true,
+      "dependencies": {
+        "empower": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
+          "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
+          "dev": true
+        }
+      }
     },
     "power-assert-context-formatter": {
       "version": "1.1.1",
@@ -797,9 +799,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.2.tgz",
-      "integrity": "sha1-YJtmQMwEJPSjlamt9ow3VWPFScc=",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
+      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
       "dev": true
     },
     "tsutils": {

--- a/.atomist/package.json
+++ b/.atomist/package.json
@@ -22,14 +22,14 @@
     "js-yaml": "^3.8.4"
   },
   "devDependencies": {
-    "@types/js-yaml": "^3.5.30",
+    "@types/js-yaml": "^3.5.31",
     "@types/mocha": "^2.2.40",
     "@types/power-assert": "^1.4.29",
     "espower-typescript": "^8.0.0",
-    "mocha": "^3.2.0",
-    "power-assert": "^1.4.2",
+    "mocha": "^3.4.2",
+    "power-assert": "^1.4.4",
     "supervisor": "^0.12.0",
-    "tslint": "^5.0.0",
+    "tslint": "^5.4.3",
     "typescript": "2.3.2"
   },
   "directories": {

--- a/.atomist/tests/project/libbit/IncrementVersionSteps.ts
+++ b/.atomist/tests/project/libbit/IncrementVersionSteps.ts
@@ -1,0 +1,25 @@
+import { Project } from "@atomist/rug/model/Project";
+import {
+    Given, ProjectScenarioWorld, Then, When,
+} from "@atomist/rug/test/project/Core";
+
+const sourceFiles = [".atomist/editors/libbits/IncrementVersion.ts"];
+const testFiles = [".atomist/mocha/IncrementVersionTest.ts"];
+
+When("the IncrementVersionLibbit is run", (p: Project, world) => {
+    const w = world as ProjectScenarioWorld;
+    const editor = w.editor("IncrementVersionLibbit");
+    w.editWith(editor, {});
+});
+
+Then("the new IncrementVersion source file exists", (p: Project, world) => {
+    return sourceFiles.every((f) => p.fileExists(f));
+});
+
+Then("the new IncrementVersion test files exist", (p: Project, world) => {
+    return testFiles.every((f) => p.fileExists(f));
+});
+
+Given("the new IncrementVersion source file already exists", (p: Project) => {
+    p.addFile(sourceFiles[0], "stuff");
+});

--- a/.atomist/tests/project/libbit/IncrementVersionTest.feature
+++ b/.atomist/tests/project/libbit/IncrementVersionTest.feature
@@ -1,0 +1,15 @@
+Feature: Lib lib libbits IncrementVersion
+  The IncrementVersion libbit editor copies IncrementVersion into your project.
+
+
+  Scenario: IncrementVersionLibbit should add sample files to the project
+    Given an empty project
+    When the IncrementVersionLibbit is run
+    Then changes were made
+    Then the new IncrementVersion source file exists
+    Then the new IncrementVersion test files exist
+
+  Scenario: IncrementVersionLibbit should do nothing when a file already exists
+    Given the new IncrementVersion source file already exists
+    When the IncrementVersionLibbit is run
+    Then no changes were made


### PR DESCRIPTION

So, I'm building this thing (and it's showing up my talks)
which is an editor that creates an editor to supply a feature
(very specific kind: a file, and its tests) to another project
that wants to copy it.

This is the output of that. I used it to copy IncrementVersion
into another project where I wanted a custom BumpVersion editor.


Any code style comments on the libbit editor here, are ones I'll apply to the libbit editor template over in satellite-of-love/libbit-rugs.

I'm going to blog about this before too long, and some examples will be useful. So when I wanted on, I made it.